### PR TITLE
Support CLAUDE_CONFIG_DIR for path resolution

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 # Build release binary (outputs mcp-server/target/release/cta-mcp-server)
 bash scripts/build.sh
 
-# Run all tests (98 tests: unit + integration)
+# Run all tests (103 tests: unit + integration)
 cargo test --all-targets --manifest-path mcp-server/Cargo.toml
 
 # Run a single test by name
@@ -59,7 +59,7 @@ This is a Rust-based Claude Code plugin that parses JSONL session logs from `~/.
 | `detector.rs` | 6-type statistical anomaly detection with severity scoring |
 | `pricing.rs` | Model pricing lookup from TOML, cost calculation per token type |
 | `archiver.rs` | zstd compression/decompression for session archival |
-| `config.rs` | Centralized path resolution across three deployment modes |
+| `config.rs` | Centralized path resolution across four deployment modes |
 | `session_finder.rs` | Recursive JSONL file discovery under projects directory |
 
 ### Plugin Structure

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ This is a Rust-based Claude Code plugin that parses JSONL session logs from `~/.
 
 - **ParseResult is zero-computation**: `parser.rs` only extracts and deduplicates data from JSONL; all cost calculations happen in `analyzer.rs` using `PricingTable`
 - **Pricing is embedded**: `config/pricing.toml` is read at runtime (or overridden via `CTA_PRICING_PATH`). Unknown models fall back to Sonnet-equivalent pricing under `[defaults]`
-- **Three-mode path resolution** (`config.rs`): env var override > `$CLAUDE_PLUGIN_ROOT` plugin mode > `$HOME/.claude/` standalone mode. Projects dir has no plugin-mode override since Claude Code always writes sessions to `~/.claude/projects/`
+- **Four-mode path resolution** (`config.rs`): env var override > `$CLAUDE_PLUGIN_ROOT` plugin mode > `$CLAUDE_CONFIG_DIR` config dir mode > `$HOME/.claude/` standalone mode
 - **Anomaly detection**: `detector.rs` uses standard deviation thresholds for 5 anomaly types, but `CostInefficient` uses absolute mean-based comparison (above-mean cost AND below-mean cache hit rate), making it independent of the `stddev_threshold` parameter
 
 ### Module Responsibilities

--- a/README.md
+++ b/README.md
@@ -79,11 +79,11 @@ Environment variables (all optional):
 | Variable | Purpose | Default |
 |----------|---------|---------|
 | `CTA_DB_PATH` | SQLite database location | `${CLAUDE_PLUGIN_ROOT}/data/token-analyzer.db` |
-| `CTA_PROJECTS_DIR` | Session logs directory | `~/.claude/projects` |
-| `CTA_ARCHIVE_DIR` | Archive directory | `~/.claude/token-analyzer-archive` |
+| `CTA_PROJECTS_DIR` | Session logs directory | `$CLAUDE_CONFIG_DIR/projects` or `~/.claude/projects` |
+| `CTA_ARCHIVE_DIR` | Archive directory | `$CLAUDE_CONFIG_DIR/token-analyzer-archive` or `~/.claude/token-analyzer-archive` |
 | `CTA_PRICING_PATH` | Custom pricing TOML | Embedded in binary |
 
-Path resolution priority: Environment variable > Plugin mode (`$CLAUDE_PLUGIN_ROOT`) > Standalone mode (`$HOME/.claude/`)
+Path resolution priority: Environment variable > Plugin mode (`$CLAUDE_PLUGIN_ROOT`) > Config dir mode (`$CLAUDE_CONFIG_DIR`) > Standalone mode (`$HOME/.claude/`)
 
 ## Building from Source
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ cd claude-token-analyzer
 bash scripts/build.sh
 # Binary: mcp-server/target/release/cta-mcp-server
 
-# Run tests (98 tests)
+# Run tests (103 tests)
 cargo test --all-targets --manifest-path mcp-server/Cargo.toml
 
 # Lint

--- a/mcp-server/src/bin/mcp.rs
+++ b/mcp-server/src/bin/mcp.rs
@@ -367,7 +367,7 @@ impl TokenAnalyzerServer {
 
     #[tool(
         name = "sync_db",
-        description = "Synchronize the database by scanning all JSONL session files under the configured projects directory (default: ~/.claude/projects/, overridable via $CTA_PROJECTS_DIR) and upserting new or modified sessions. Returns a sync report with counts of files scanned, synced, and failed."
+        description = "Synchronize the database by scanning all JSONL session files under the configured projects directory (default: $CLAUDE_CONFIG_DIR/projects/ or ~/.claude/projects/, overridable via $CTA_PROJECTS_DIR) and upserting new or modified sessions. Returns a sync report with counts of files scanned, synced, and failed."
     )]
     async fn sync_db_tool(
         &self,

--- a/mcp-server/src/config.rs
+++ b/mcp-server/src/config.rs
@@ -3,7 +3,8 @@
 //! Resolution priority:
 //! 1. Environment variable override ($CTA_DB_PATH, $CTA_PROJECTS_DIR, $CTA_ARCHIVE_DIR)
 //! 2. Plugin mode ($CLAUDE_PLUGIN_ROOT/data/...)
-//! 3. Standalone mode ($HOME/.claude/...)
+//! 3. Config dir mode ($CLAUDE_CONFIG_DIR/...)
+//! 4. Standalone mode ($HOME/.claude/...)
 
 use std::env;
 use std::path::PathBuf;
@@ -12,7 +13,7 @@ use anyhow::{Context, Result};
 
 /// Resolve the database file path.
 ///
-/// Priority: `$CTA_DB_PATH` > `$CLAUDE_PLUGIN_ROOT/data/token-analyzer.db` > `$HOME/.claude/token-analyzer.db`
+/// Priority: `$CTA_DB_PATH` > `$CLAUDE_PLUGIN_ROOT/data/token-analyzer.db` > `$CLAUDE_CONFIG_DIR/token-analyzer.db` > `$HOME/.claude/token-analyzer.db`
 pub fn resolve_db_path() -> Result<PathBuf> {
     if let Ok(p) = env::var("CTA_DB_PATH") {
         return Ok(PathBuf::from(p));
@@ -20,27 +21,27 @@ pub fn resolve_db_path() -> Result<PathBuf> {
     if let Ok(root) = env::var("CLAUDE_PLUGIN_ROOT") {
         return Ok(PathBuf::from(root).join("data").join("token-analyzer.db"));
     }
-    let home = home_dir()?;
-    Ok(home.join(".claude").join("token-analyzer.db"))
+    let base = claude_config_dir_or_home()?;
+    Ok(base.join("token-analyzer.db"))
 }
 
 /// Resolve the projects directory path.
 ///
-/// Priority: `$CTA_PROJECTS_DIR` > `$HOME/.claude/projects`
+/// Priority: `$CTA_PROJECTS_DIR` > `$CLAUDE_CONFIG_DIR/projects` > `$HOME/.claude/projects`
 ///
-/// Note: No plugin-mode override — projects dir is always under `~/.claude/projects`
-/// because that's where Claude Code stores session data regardless of plugin installation.
+/// Note: No plugin-mode override — Claude Code writes session data to its config
+/// directory, which defaults to `~/.claude/` but can be overridden via `$CLAUDE_CONFIG_DIR`.
 pub fn resolve_projects_dir() -> Result<PathBuf> {
     if let Ok(p) = env::var("CTA_PROJECTS_DIR") {
         return Ok(PathBuf::from(p));
     }
-    let home = home_dir()?;
-    Ok(home.join(".claude").join("projects"))
+    let base = claude_config_dir_or_home()?;
+    Ok(base.join("projects"))
 }
 
 /// Resolve the archive directory path.
 ///
-/// Priority: `$CTA_ARCHIVE_DIR` > `$CLAUDE_PLUGIN_ROOT/data/token-analyzer-archive` > `$HOME/.claude/token-analyzer-archive`
+/// Priority: `$CTA_ARCHIVE_DIR` > `$CLAUDE_PLUGIN_ROOT/data/token-analyzer-archive` > `$CLAUDE_CONFIG_DIR/token-analyzer-archive` > `$HOME/.claude/token-analyzer-archive`
 pub fn resolve_archive_dir() -> Result<PathBuf> {
     if let Ok(p) = env::var("CTA_ARCHIVE_DIR") {
         return Ok(PathBuf::from(p));
@@ -50,13 +51,24 @@ pub fn resolve_archive_dir() -> Result<PathBuf> {
             .join("data")
             .join("token-analyzer-archive"));
     }
+    let base = claude_config_dir_or_home()?;
+    Ok(base.join("token-analyzer-archive"))
+}
+
+/// Resolve the base config directory.
+///
+/// Returns `$CLAUDE_CONFIG_DIR` if set, otherwise `$HOME/.claude`.
+fn claude_config_dir_or_home() -> Result<PathBuf> {
+    if let Ok(dir) = env::var("CLAUDE_CONFIG_DIR") {
+        return Ok(PathBuf::from(dir));
+    }
     let home = home_dir()?;
-    Ok(home.join(".claude").join("token-analyzer-archive"))
+    Ok(home.join(".claude"))
 }
 
 fn home_dir() -> Result<PathBuf> {
     env::var("HOME").map(PathBuf::from).context(
-        "HOME environment variable not set (and no CTA_DB_PATH / CLAUDE_PLUGIN_ROOT override)",
+        "HOME environment variable not set (and no CTA_DB_PATH / CLAUDE_PLUGIN_ROOT / CLAUDE_CONFIG_DIR override)",
     )
 }
 
@@ -121,11 +133,30 @@ mod tests {
     }
 
     #[test]
+    fn test_resolve_db_path_config_dir() {
+        with_env_vars(
+            &[
+                ("CTA_DB_PATH", None),
+                ("CLAUDE_PLUGIN_ROOT", None),
+                ("CLAUDE_CONFIG_DIR", Some("/custom/claude-config")),
+            ],
+            || {
+                let path = resolve_db_path().unwrap();
+                assert_eq!(
+                    path,
+                    PathBuf::from("/custom/claude-config/token-analyzer.db")
+                );
+            },
+        );
+    }
+
+    #[test]
     fn test_resolve_db_path_standalone() {
         with_env_vars(
             &[
                 ("CTA_DB_PATH", None),
                 ("CLAUDE_PLUGIN_ROOT", None),
+                ("CLAUDE_CONFIG_DIR", None),
                 ("HOME", Some("/home/testuser")),
             ],
             || {
@@ -147,9 +178,30 @@ mod tests {
     }
 
     #[test]
+    fn test_resolve_projects_dir_config_dir() {
+        with_env_vars(
+            &[
+                ("CTA_PROJECTS_DIR", None),
+                ("CLAUDE_CONFIG_DIR", Some("/custom/claude-config")),
+            ],
+            || {
+                let path = resolve_projects_dir().unwrap();
+                assert_eq!(
+                    path,
+                    PathBuf::from("/custom/claude-config/projects")
+                );
+            },
+        );
+    }
+
+    #[test]
     fn test_resolve_projects_dir_default() {
         with_env_vars(
-            &[("CTA_PROJECTS_DIR", None), ("HOME", Some("/home/testuser"))],
+            &[
+                ("CTA_PROJECTS_DIR", None),
+                ("CLAUDE_CONFIG_DIR", None),
+                ("HOME", Some("/home/testuser")),
+            ],
             || {
                 let path = resolve_projects_dir().unwrap();
                 assert_eq!(path, PathBuf::from("/home/testuser/.claude/projects"));
@@ -158,11 +210,64 @@ mod tests {
     }
 
     #[test]
-    fn test_resolve_fails_without_home() {
+    fn test_resolve_archive_dir_config_dir() {
+        with_env_vars(
+            &[
+                ("CTA_ARCHIVE_DIR", None),
+                ("CLAUDE_PLUGIN_ROOT", None),
+                ("CLAUDE_CONFIG_DIR", Some("/custom/claude-config")),
+            ],
+            || {
+                let path = resolve_archive_dir().unwrap();
+                assert_eq!(
+                    path,
+                    PathBuf::from("/custom/claude-config/token-analyzer-archive")
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn test_plugin_root_takes_priority_over_config_dir() {
+        with_env_vars(
+            &[
+                ("CTA_DB_PATH", None),
+                ("CLAUDE_PLUGIN_ROOT", Some("/plugins/cta")),
+                ("CLAUDE_CONFIG_DIR", Some("/custom/claude-config")),
+            ],
+            || {
+                let path = resolve_db_path().unwrap();
+                assert_eq!(path, PathBuf::from("/plugins/cta/data/token-analyzer.db"));
+            },
+        );
+    }
+
+    #[test]
+    fn test_config_dir_fallback_without_home() {
         with_env_vars(
             &[
                 ("CTA_DB_PATH", None),
                 ("CLAUDE_PLUGIN_ROOT", None),
+                ("CLAUDE_CONFIG_DIR", Some("/custom/claude-config")),
+                ("HOME", None),
+            ],
+            || {
+                let path = resolve_db_path().unwrap();
+                assert_eq!(
+                    path,
+                    PathBuf::from("/custom/claude-config/token-analyzer.db")
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn test_resolve_fails_without_home_or_config_dir() {
+        with_env_vars(
+            &[
+                ("CTA_DB_PATH", None),
+                ("CLAUDE_PLUGIN_ROOT", None),
+                ("CLAUDE_CONFIG_DIR", None),
                 ("HOME", None),
             ],
             || {


### PR DESCRIPTION
## Summary

- Add `CLAUDE_CONFIG_DIR` as a fallback in `config.rs` path resolution, between plugin mode (`CLAUDE_PLUGIN_ROOT`) and standalone mode (`$HOME/.claude`)
- Add `claude_config_dir_or_home()` helper used by all three resolve functions (`resolve_db_path`, `resolve_projects_dir`, `resolve_archive_dir`)
- Add 5 new tests covering config dir for db/projects/archive, priority ordering, and HOME-less fallback

Fixes #6

## Test plan

- [x] All 103 tests pass (88 unit + 15 integration) — `cargo test --all-targets`
- [x] 11 config-specific tests pass including 5 new CLAUDE_CONFIG_DIR tests
- [x] Built release binary and tested locally with MCP config pointing to `~/.local/bin/cta-mcp-server`
- [x] Verified `CLAUDE_PLUGIN_ROOT` still takes priority over `CLAUDE_CONFIG_DIR`
- [x] Verified `$HOME/.claude` fallback still works when neither env var is set
- [x] Pre-existing clippy warnings in `format.rs` are unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)