### PR TITLE
Support CLAUDE_CONFIG_DIR for projects only (split behavior)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,12 +23,12 @@ cargo run --manifest-path mcp-server/Cargo.toml --bin cta -- <command>
 
 ## Architecture
 
-This is a Rust-based Claude Code plugin that parses JSONL session logs from `~/.claude/projects/` and provides token usage analytics via MCP tools and a CLI.
+This is a Rust-based Claude Code plugin that parses JSONL session logs from `CTA_PROJECTS_DIR` when set, otherwise `$CLAUDE_CONFIG_DIR/projects/`, otherwise `~/.claude/projects/`, and provides token usage analytics via MCP tools and a CLI.
 
 ### Data Pipeline
 
 ```
-~/.claude/projects/**/*.jsonl
+$CTA_PROJECTS_DIR/**/*.jsonl or $CLAUDE_CONFIG_DIR/projects/**/*.jsonl or ~/.claude/projects/**/*.jsonl
     → parser.rs    : JSONL lines → ParseResult (zero-computation, deduplicates partial/final responses)
     → analyzer.rs  : ParseResult → SessionAnalysis (cost calculation via pricing.rs, 10-dimension metrics)
     → storage.rs   : SessionAnalysis → SQLite (upsert with change detection)
@@ -46,7 +46,7 @@ This is a Rust-based Claude Code plugin that parses JSONL session logs from `~/.
 
 - **ParseResult is zero-computation**: `parser.rs` only extracts and deduplicates data from JSONL; all cost calculations happen in `analyzer.rs` using `PricingTable`
 - **Pricing is embedded**: `config/pricing.toml` is read at runtime (or overridden via `CTA_PRICING_PATH`). Unknown models fall back to Sonnet-equivalent pricing under `[defaults]`
-- **Four-mode path resolution** (`config.rs`): env var override > `$CLAUDE_PLUGIN_ROOT` plugin mode > `$CLAUDE_CONFIG_DIR` config dir mode > `$HOME/.claude/` standalone mode
+- **Path resolution** (`config.rs`): DB/archive use env var override > `$CLAUDE_PLUGIN_ROOT` plugin mode > `$HOME/.claude/` standalone mode. Projects dir uses env var override > `$CLAUDE_CONFIG_DIR/projects` > `$HOME/.claude/projects/` and still has no plugin-root override.
 - **Anomaly detection**: `detector.rs` uses standard deviation thresholds for 5 anomaly types, but `CostInefficient` uses absolute mean-based comparison (above-mean cost AND below-mean cache hit rate), making it independent of the `stddev_threshold` parameter
 
 ### Module Responsibilities
@@ -59,7 +59,7 @@ This is a Rust-based Claude Code plugin that parses JSONL session logs from `~/.
 | `detector.rs` | 6-type statistical anomaly detection with severity scoring |
 | `pricing.rs` | Model pricing lookup from TOML, cost calculation per token type |
 | `archiver.rs` | zstd compression/decompression for session archival |
-| `config.rs` | Centralized path resolution across four deployment modes |
+| `config.rs` | Centralized path resolution across three deployment modes (with `$CLAUDE_CONFIG_DIR` fallback for projects only) |
 | `session_finder.rs` | Recursive JSONL file discovery under projects directory |
 
 ### Plugin Structure

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 # Build release binary (outputs mcp-server/target/release/cta-mcp-server)
 bash scripts/build.sh
 
-# Run all tests (103 tests: unit + integration)
+# Run all tests (106 tests: unit + integration)
 cargo test --all-targets --manifest-path mcp-server/Cargo.toml
 
 # Run a single test by name

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 # Build release binary (outputs mcp-server/target/release/cta-mcp-server)
 bash scripts/build.sh
 
-# Run all tests (98 tests: unit + integration)
+# Run all tests (103 tests: unit + integration)
 cargo test --all-targets --manifest-path mcp-server/Cargo.toml
 
 # Run a single test by name
@@ -59,7 +59,7 @@ This is a Rust-based Claude Code plugin that parses JSONL session logs from `~/.
 | `detector.rs` | 6-type statistical anomaly detection with severity scoring |
 | `pricing.rs` | Model pricing lookup from TOML, cost calculation per token type |
 | `archiver.rs` | zstd compression/decompression for session archival |
-| `config.rs` | Centralized path resolution across three deployment modes |
+| `config.rs` | Centralized path resolution across four deployment modes |
 | `session_finder.rs` | Recursive JSONL file discovery under projects directory |
 
 ### Plugin Structure

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ This is a Rust-based Claude Code plugin that parses JSONL session logs from `~/.
 
 - **ParseResult is zero-computation**: `parser.rs` only extracts and deduplicates data from JSONL; all cost calculations happen in `analyzer.rs` using `PricingTable`
 - **Pricing is embedded**: `config/pricing.toml` is read at runtime (or overridden via `CTA_PRICING_PATH`). Unknown models fall back to Sonnet-equivalent pricing under `[defaults]`
-- **Three-mode path resolution** (`config.rs`): env var override > `$CLAUDE_PLUGIN_ROOT` plugin mode > `$HOME/.claude/` standalone mode. Projects dir has no plugin-mode override since Claude Code always writes sessions to `~/.claude/projects/`
+- **Four-mode path resolution** (`config.rs`): env var override > `$CLAUDE_PLUGIN_ROOT` plugin mode > `$CLAUDE_CONFIG_DIR` config dir mode > `$HOME/.claude/` standalone mode
 - **Anomaly detection**: `detector.rs` uses standard deviation thresholds for 5 anomaly types, but `CostInefficient` uses absolute mean-based comparison (above-mean cost AND below-mean cache hit rate), making it independent of the `stddev_threshold` parameter
 
 ### Module Responsibilities

--- a/README.md
+++ b/README.md
@@ -79,11 +79,11 @@ Environment variables (all optional):
 | Variable | Purpose | Default |
 |----------|---------|---------|
 | `CTA_DB_PATH` | SQLite database location | `${CLAUDE_PLUGIN_ROOT}/data/token-analyzer.db` |
-| `CTA_PROJECTS_DIR` | Session logs directory | `~/.claude/projects` |
-| `CTA_ARCHIVE_DIR` | Archive directory | `~/.claude/token-analyzer-archive` |
+| `CTA_PROJECTS_DIR` | Session logs directory | `$CLAUDE_CONFIG_DIR/projects` or `~/.claude/projects` |
+| `CTA_ARCHIVE_DIR` | Archive directory | `$CLAUDE_CONFIG_DIR/token-analyzer-archive` or `~/.claude/token-analyzer-archive` |
 | `CTA_PRICING_PATH` | Custom pricing TOML | Embedded in binary |
 
-Path resolution priority: Environment variable > Plugin mode (`$CLAUDE_PLUGIN_ROOT`) > Standalone mode (`$HOME/.claude/`)
+Path resolution priority: Environment variable > Plugin mode (`$CLAUDE_PLUGIN_ROOT`) > Config dir mode (`$CLAUDE_CONFIG_DIR`) > Standalone mode (`$HOME/.claude/`)
 
 ## Building from Source
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ cd claude-token-analyzer
 bash scripts/build.sh
 # Binary: mcp-server/target/release/cta-mcp-server
 
-# Run tests (98 tests)
+# Run tests (103 tests)
 cargo test --all-targets --manifest-path mcp-server/Cargo.toml
 
 # Lint

--- a/README.md
+++ b/README.md
@@ -78,12 +78,15 @@ Environment variables (all optional):
 
 | Variable | Purpose | Default |
 |----------|---------|---------|
-| `CTA_DB_PATH` | SQLite database location | `${CLAUDE_PLUGIN_ROOT}/data/token-analyzer.db` |
-| `CTA_PROJECTS_DIR` | Session logs directory | `$CLAUDE_CONFIG_DIR/projects` or `~/.claude/projects` |
-| `CTA_ARCHIVE_DIR` | Archive directory | `$CLAUDE_CONFIG_DIR/token-analyzer-archive` or `~/.claude/token-analyzer-archive` |
+| `CTA_DB_PATH` | SQLite database location | `${CLAUDE_PLUGIN_ROOT}/data/token-analyzer.db` or `~/.claude/token-analyzer.db` |
+| `CTA_PROJECTS_DIR` | Session logs directory | `${CLAUDE_CONFIG_DIR}/projects` or `~/.claude/projects` |
+| `CTA_ARCHIVE_DIR` | Archive directory | `${CLAUDE_PLUGIN_ROOT}/data/token-analyzer-archive` or `~/.claude/token-analyzer-archive` |
 | `CTA_PRICING_PATH` | Custom pricing TOML | Embedded in binary |
+| `CLAUDE_CONFIG_DIR` | Claude config root for session logs | unset |
 
-Path resolution priority: Environment variable > Plugin mode (`$CLAUDE_PLUGIN_ROOT`) > Config dir mode (`$CLAUDE_CONFIG_DIR`) > Standalone mode (`$HOME/.claude/`)
+Path resolution priority:
+- DB/archive: environment variable > plugin mode (`$CLAUDE_PLUGIN_ROOT`) > standalone mode (`$HOME/.claude/`)
+- Projects: environment variable > Claude config dir (`$CLAUDE_CONFIG_DIR/projects`) > standalone mode (`$HOME/.claude/projects`)
 
 ## Building from Source
 
@@ -93,7 +96,7 @@ cd claude-token-analyzer
 bash scripts/build.sh
 # Binary: mcp-server/target/release/cta-mcp-server
 
-# Run tests (103 tests)
+# Run tests (105 tests)
 cargo test --all-targets --manifest-path mcp-server/Cargo.toml
 
 # Lint

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Then just ask in any Claude Code session:
     → MCP tools / Skills            You ask, it answers
 ```
 
-All processing happens locally. The SQLite database lives in the plugin directory. No network calls, no external dependencies at runtime.
+All processing happens locally. The SQLite database lives under the plugin data directory in plugin mode and falls back to `~/.claude/` in standalone mode. No network calls, no external dependencies at runtime.
 
 ## Skills
 
@@ -96,7 +96,7 @@ cd claude-token-analyzer
 bash scripts/build.sh
 # Binary: mcp-server/target/release/cta-mcp-server
 
-# Run tests (105 tests)
+# Run tests (106 tests)
 cargo test --all-targets --manifest-path mcp-server/Cargo.toml
 
 # Lint

--- a/mcp-server/src/bin/mcp.rs
+++ b/mcp-server/src/bin/mcp.rs
@@ -367,7 +367,7 @@ impl TokenAnalyzerServer {
 
     #[tool(
         name = "sync_db",
-        description = "Synchronize the database by scanning all JSONL session files under the configured projects directory (default: ~/.claude/projects/, overridable via $CTA_PROJECTS_DIR) and upserting new or modified sessions. Returns a sync report with counts of files scanned, synced, and failed."
+        description = "Synchronize the database by scanning all JSONL session files under the configured projects directory (default: $CLAUDE_CONFIG_DIR/projects/ or ~/.claude/projects/, overridable via $CTA_PROJECTS_DIR) and upserting new or modified sessions. Returns a sync report with counts of files scanned, synced, and failed."
     )]
     async fn sync_db_tool(
         &self,

--- a/mcp-server/src/config.rs
+++ b/mcp-server/src/config.rs
@@ -3,7 +3,8 @@
 //! Resolution priority:
 //! 1. Environment variable override ($CTA_DB_PATH, $CTA_PROJECTS_DIR, $CTA_ARCHIVE_DIR)
 //! 2. Plugin mode ($CLAUDE_PLUGIN_ROOT/data/...)
-//! 3. Standalone mode ($HOME/.claude/...)
+//! 3. Config dir mode ($CLAUDE_CONFIG_DIR/...)
+//! 4. Standalone mode ($HOME/.claude/...)
 
 use std::env;
 use std::path::PathBuf;
@@ -12,7 +13,7 @@ use anyhow::{Context, Result};
 
 /// Resolve the database file path.
 ///
-/// Priority: `$CTA_DB_PATH` > `$CLAUDE_PLUGIN_ROOT/data/token-analyzer.db` > `$HOME/.claude/token-analyzer.db`
+/// Priority: `$CTA_DB_PATH` > `$CLAUDE_PLUGIN_ROOT/data/token-analyzer.db` > `$CLAUDE_CONFIG_DIR/token-analyzer.db` > `$HOME/.claude/token-analyzer.db`
 pub fn resolve_db_path() -> Result<PathBuf> {
     if let Ok(p) = env::var("CTA_DB_PATH") {
         return Ok(PathBuf::from(p));
@@ -20,27 +21,27 @@ pub fn resolve_db_path() -> Result<PathBuf> {
     if let Ok(root) = env::var("CLAUDE_PLUGIN_ROOT") {
         return Ok(PathBuf::from(root).join("data").join("token-analyzer.db"));
     }
-    let home = home_dir()?;
-    Ok(home.join(".claude").join("token-analyzer.db"))
+    let base = claude_config_dir_or_home()?;
+    Ok(base.join("token-analyzer.db"))
 }
 
 /// Resolve the projects directory path.
 ///
-/// Priority: `$CTA_PROJECTS_DIR` > `$HOME/.claude/projects`
+/// Priority: `$CTA_PROJECTS_DIR` > `$CLAUDE_CONFIG_DIR/projects` > `$HOME/.claude/projects`
 ///
-/// Note: No plugin-mode override — projects dir is always under `~/.claude/projects`
-/// because that's where Claude Code stores session data regardless of plugin installation.
+/// Note: No plugin-mode override — Claude Code writes session data to its config
+/// directory, which defaults to `~/.claude/` but can be overridden via `$CLAUDE_CONFIG_DIR`.
 pub fn resolve_projects_dir() -> Result<PathBuf> {
     if let Ok(p) = env::var("CTA_PROJECTS_DIR") {
         return Ok(PathBuf::from(p));
     }
-    let home = home_dir()?;
-    Ok(home.join(".claude").join("projects"))
+    let base = claude_config_dir_or_home()?;
+    Ok(base.join("projects"))
 }
 
 /// Resolve the archive directory path.
 ///
-/// Priority: `$CTA_ARCHIVE_DIR` > `$CLAUDE_PLUGIN_ROOT/data/token-analyzer-archive` > `$HOME/.claude/token-analyzer-archive`
+/// Priority: `$CTA_ARCHIVE_DIR` > `$CLAUDE_PLUGIN_ROOT/data/token-analyzer-archive` > `$CLAUDE_CONFIG_DIR/token-analyzer-archive` > `$HOME/.claude/token-analyzer-archive`
 pub fn resolve_archive_dir() -> Result<PathBuf> {
     if let Ok(p) = env::var("CTA_ARCHIVE_DIR") {
         return Ok(PathBuf::from(p));
@@ -50,13 +51,24 @@ pub fn resolve_archive_dir() -> Result<PathBuf> {
             .join("data")
             .join("token-analyzer-archive"));
     }
+    let base = claude_config_dir_or_home()?;
+    Ok(base.join("token-analyzer-archive"))
+}
+
+/// Resolve the base config directory.
+///
+/// Returns `$CLAUDE_CONFIG_DIR` if set, otherwise `$HOME/.claude`.
+fn claude_config_dir_or_home() -> Result<PathBuf> {
+    if let Ok(dir) = env::var("CLAUDE_CONFIG_DIR") {
+        return Ok(PathBuf::from(dir));
+    }
     let home = home_dir()?;
-    Ok(home.join(".claude").join("token-analyzer-archive"))
+    Ok(home.join(".claude"))
 }
 
 fn home_dir() -> Result<PathBuf> {
     env::var("HOME").map(PathBuf::from).context(
-        "HOME environment variable not set (and no CTA_DB_PATH / CLAUDE_PLUGIN_ROOT override)",
+        "HOME environment variable not set (and no CTA_DB_PATH / CLAUDE_PLUGIN_ROOT / CLAUDE_CONFIG_DIR override)",
     )
 }
 
@@ -121,11 +133,30 @@ mod tests {
     }
 
     #[test]
+    fn test_resolve_db_path_config_dir() {
+        with_env_vars(
+            &[
+                ("CTA_DB_PATH", None),
+                ("CLAUDE_PLUGIN_ROOT", None),
+                ("CLAUDE_CONFIG_DIR", Some("/custom/claude-config")),
+            ],
+            || {
+                let path = resolve_db_path().unwrap();
+                assert_eq!(
+                    path,
+                    PathBuf::from("/custom/claude-config/token-analyzer.db")
+                );
+            },
+        );
+    }
+
+    #[test]
     fn test_resolve_db_path_standalone() {
         with_env_vars(
             &[
                 ("CTA_DB_PATH", None),
                 ("CLAUDE_PLUGIN_ROOT", None),
+                ("CLAUDE_CONFIG_DIR", None),
                 ("HOME", Some("/home/testuser")),
             ],
             || {
@@ -147,9 +178,30 @@ mod tests {
     }
 
     #[test]
+    fn test_resolve_projects_dir_config_dir() {
+        with_env_vars(
+            &[
+                ("CTA_PROJECTS_DIR", None),
+                ("CLAUDE_CONFIG_DIR", Some("/custom/claude-config")),
+            ],
+            || {
+                let path = resolve_projects_dir().unwrap();
+                assert_eq!(
+                    path,
+                    PathBuf::from("/custom/claude-config/projects")
+                );
+            },
+        );
+    }
+
+    #[test]
     fn test_resolve_projects_dir_default() {
         with_env_vars(
-            &[("CTA_PROJECTS_DIR", None), ("HOME", Some("/home/testuser"))],
+            &[
+                ("CTA_PROJECTS_DIR", None),
+                ("CLAUDE_CONFIG_DIR", None),
+                ("HOME", Some("/home/testuser")),
+            ],
             || {
                 let path = resolve_projects_dir().unwrap();
                 assert_eq!(path, PathBuf::from("/home/testuser/.claude/projects"));
@@ -158,11 +210,64 @@ mod tests {
     }
 
     #[test]
-    fn test_resolve_fails_without_home() {
+    fn test_resolve_archive_dir_config_dir() {
+        with_env_vars(
+            &[
+                ("CTA_ARCHIVE_DIR", None),
+                ("CLAUDE_PLUGIN_ROOT", None),
+                ("CLAUDE_CONFIG_DIR", Some("/custom/claude-config")),
+            ],
+            || {
+                let path = resolve_archive_dir().unwrap();
+                assert_eq!(
+                    path,
+                    PathBuf::from("/custom/claude-config/token-analyzer-archive")
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn test_plugin_root_takes_priority_over_config_dir() {
+        with_env_vars(
+            &[
+                ("CTA_DB_PATH", None),
+                ("CLAUDE_PLUGIN_ROOT", Some("/plugins/cta")),
+                ("CLAUDE_CONFIG_DIR", Some("/custom/claude-config")),
+            ],
+            || {
+                let path = resolve_db_path().unwrap();
+                assert_eq!(path, PathBuf::from("/plugins/cta/data/token-analyzer.db"));
+            },
+        );
+    }
+
+    #[test]
+    fn test_config_dir_fallback_without_home() {
         with_env_vars(
             &[
                 ("CTA_DB_PATH", None),
                 ("CLAUDE_PLUGIN_ROOT", None),
+                ("CLAUDE_CONFIG_DIR", Some("/custom/claude-config")),
+                ("HOME", None),
+            ],
+            || {
+                let path = resolve_db_path().unwrap();
+                assert_eq!(
+                    path,
+                    PathBuf::from("/custom/claude-config/token-analyzer.db")
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn test_resolve_fails_without_home_or_config_dir() {
+        with_env_vars(
+            &[
+                ("CTA_DB_PATH", None),
+                ("CLAUDE_PLUGIN_ROOT", None),
+                ("CLAUDE_CONFIG_DIR", None),
                 ("HOME", None),
             ],
             || {

--- a/mcp-server/src/config.rs
+++ b/mcp-server/src/config.rs
@@ -1,10 +1,13 @@
 //! Centralized path resolution for CTA.
 //!
 //! Resolution priority:
-//! 1. Environment variable override ($CTA_DB_PATH, $CTA_PROJECTS_DIR, $CTA_ARCHIVE_DIR)
-//! 2. Plugin mode ($CLAUDE_PLUGIN_ROOT/data/...) for DB/archive only
-//! 3. Claude config dir ($CLAUDE_CONFIG_DIR/...)
-//! 4. Standalone mode ($HOME/.claude/...)
+//! - DB path: `$CTA_DB_PATH` > `$CLAUDE_PLUGIN_ROOT/data/token-analyzer.db`
+//!   > `$HOME/.claude/token-analyzer.db`
+//! - Projects dir: `$CTA_PROJECTS_DIR` > `$CLAUDE_CONFIG_DIR/projects`
+//!   > `$HOME/.claude/projects`
+//! - Archive dir: `$CTA_ARCHIVE_DIR`
+//!   > `$CLAUDE_PLUGIN_ROOT/data/token-analyzer-archive`
+//!   > `$HOME/.claude/token-analyzer-archive`
 
 use std::env;
 use std::path::PathBuf;
@@ -67,44 +70,7 @@ fn home_dir() -> Result<PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Mutex;
-
-    // Serialize env-var tests to avoid races
-    static ENV_LOCK: Mutex<()> = Mutex::new(());
-
-    /// Helper: run closure with env vars set, then restore originals
-    fn with_env_vars<F: FnOnce() -> R, R>(vars: &[(&str, Option<&str>)], f: F) -> R {
-        // Recover from poisoned mutex so that a panicking test (e.g., a TDD red-light test
-        // that intentionally fails an assertion) does not cascade and corrupt ENV state
-        // for subsequent tests. Using unwrap_or_else(|e| e.into_inner()) is the standard
-        // Rust pattern for poison recovery in test helpers.
-        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-        let originals: Vec<(&str, Option<String>)> =
-            vars.iter().map(|(k, _)| (*k, env::var(k).ok())).collect();
-
-        for (k, v) in vars {
-            // SAFETY: tests are serialized via ENV_LOCK mutex
-            unsafe {
-                match v {
-                    Some(val) => env::set_var(k, val),
-                    None => env::remove_var(k),
-                }
-            }
-        }
-
-        let result = f();
-
-        for (k, orig) in &originals {
-            // SAFETY: tests are serialized via ENV_LOCK mutex
-            unsafe {
-                match orig {
-                    Some(val) => env::set_var(k, val),
-                    None => env::remove_var(k),
-                }
-            }
-        }
-        result
-    }
+    use crate::test_utils::with_env_vars;
 
     #[test]
     fn test_resolve_db_path_from_env() {

--- a/mcp-server/src/config.rs
+++ b/mcp-server/src/config.rs
@@ -2,8 +2,8 @@
 //!
 //! Resolution priority:
 //! 1. Environment variable override ($CTA_DB_PATH, $CTA_PROJECTS_DIR, $CTA_ARCHIVE_DIR)
-//! 2. Plugin mode ($CLAUDE_PLUGIN_ROOT/data/...)
-//! 3. Config dir mode ($CLAUDE_CONFIG_DIR/...)
+//! 2. Plugin mode ($CLAUDE_PLUGIN_ROOT/data/...) for DB/archive only
+//! 3. Claude config dir ($CLAUDE_CONFIG_DIR/...)
 //! 4. Standalone mode ($HOME/.claude/...)
 
 use std::env;
@@ -13,7 +13,7 @@ use anyhow::{Context, Result};
 
 /// Resolve the database file path.
 ///
-/// Priority: `$CTA_DB_PATH` > `$CLAUDE_PLUGIN_ROOT/data/token-analyzer.db` > `$CLAUDE_CONFIG_DIR/token-analyzer.db` > `$HOME/.claude/token-analyzer.db`
+/// Priority: `$CTA_DB_PATH` > `$CLAUDE_PLUGIN_ROOT/data/token-analyzer.db` > `$HOME/.claude/token-analyzer.db`
 pub fn resolve_db_path() -> Result<PathBuf> {
     if let Ok(p) = env::var("CTA_DB_PATH") {
         return Ok(PathBuf::from(p));
@@ -21,27 +21,30 @@ pub fn resolve_db_path() -> Result<PathBuf> {
     if let Ok(root) = env::var("CLAUDE_PLUGIN_ROOT") {
         return Ok(PathBuf::from(root).join("data").join("token-analyzer.db"));
     }
-    let base = claude_config_dir_or_home()?;
-    Ok(base.join("token-analyzer.db"))
+    let home = home_dir()?;
+    Ok(home.join(".claude").join("token-analyzer.db"))
 }
 
 /// Resolve the projects directory path.
 ///
 /// Priority: `$CTA_PROJECTS_DIR` > `$CLAUDE_CONFIG_DIR/projects` > `$HOME/.claude/projects`
 ///
-/// Note: No plugin-mode override — Claude Code writes session data to its config
-/// directory, which defaults to `~/.claude/` but can be overridden via `$CLAUDE_CONFIG_DIR`.
+/// Note: No plugin-mode override — Claude Code writes session logs under the
+/// Claude config directory, not under the plugin root.
 pub fn resolve_projects_dir() -> Result<PathBuf> {
     if let Ok(p) = env::var("CTA_PROJECTS_DIR") {
         return Ok(PathBuf::from(p));
     }
-    let base = claude_config_dir_or_home()?;
-    Ok(base.join("projects"))
+    if let Ok(config_dir) = env::var("CLAUDE_CONFIG_DIR") {
+        return Ok(PathBuf::from(config_dir).join("projects"));
+    }
+    let home = home_dir()?;
+    Ok(home.join(".claude").join("projects"))
 }
 
 /// Resolve the archive directory path.
 ///
-/// Priority: `$CTA_ARCHIVE_DIR` > `$CLAUDE_PLUGIN_ROOT/data/token-analyzer-archive` > `$CLAUDE_CONFIG_DIR/token-analyzer-archive` > `$HOME/.claude/token-analyzer-archive`
+/// Priority: `$CTA_ARCHIVE_DIR` > `$CLAUDE_PLUGIN_ROOT/data/token-analyzer-archive` > `$HOME/.claude/token-analyzer-archive`
 pub fn resolve_archive_dir() -> Result<PathBuf> {
     if let Ok(p) = env::var("CTA_ARCHIVE_DIR") {
         return Ok(PathBuf::from(p));
@@ -51,24 +54,13 @@ pub fn resolve_archive_dir() -> Result<PathBuf> {
             .join("data")
             .join("token-analyzer-archive"));
     }
-    let base = claude_config_dir_or_home()?;
-    Ok(base.join("token-analyzer-archive"))
-}
-
-/// Resolve the base config directory.
-///
-/// Returns `$CLAUDE_CONFIG_DIR` if set, otherwise `$HOME/.claude`.
-fn claude_config_dir_or_home() -> Result<PathBuf> {
-    if let Ok(dir) = env::var("CLAUDE_CONFIG_DIR") {
-        return Ok(PathBuf::from(dir));
-    }
     let home = home_dir()?;
-    Ok(home.join(".claude"))
+    Ok(home.join(".claude").join("token-analyzer-archive"))
 }
 
 fn home_dir() -> Result<PathBuf> {
     env::var("HOME").map(PathBuf::from).context(
-        "HOME environment variable not set (and no CTA_DB_PATH / CLAUDE_PLUGIN_ROOT / CLAUDE_CONFIG_DIR override)",
+        "HOME environment variable not set (and no CTA_DB_PATH / CLAUDE_PLUGIN_ROOT override)",
     )
 }
 
@@ -82,7 +74,11 @@ mod tests {
 
     /// Helper: run closure with env vars set, then restore originals
     fn with_env_vars<F: FnOnce() -> R, R>(vars: &[(&str, Option<&str>)], f: F) -> R {
-        let _guard = ENV_LOCK.lock().unwrap();
+        // Recover from poisoned mutex so that a panicking test (e.g., a TDD red-light test
+        // that intentionally fails an assertion) does not cascade and corrupt ENV state
+        // for subsequent tests. Using unwrap_or_else(|e| e.into_inner()) is the standard
+        // Rust pattern for poison recovery in test helpers.
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let originals: Vec<(&str, Option<String>)> =
             vars.iter().map(|(k, _)| (*k, env::var(k).ok())).collect();
 
@@ -133,30 +129,11 @@ mod tests {
     }
 
     #[test]
-    fn test_resolve_db_path_config_dir() {
-        with_env_vars(
-            &[
-                ("CTA_DB_PATH", None),
-                ("CLAUDE_PLUGIN_ROOT", None),
-                ("CLAUDE_CONFIG_DIR", Some("/custom/claude-config")),
-            ],
-            || {
-                let path = resolve_db_path().unwrap();
-                assert_eq!(
-                    path,
-                    PathBuf::from("/custom/claude-config/token-analyzer.db")
-                );
-            },
-        );
-    }
-
-    #[test]
     fn test_resolve_db_path_standalone() {
         with_env_vars(
             &[
                 ("CTA_DB_PATH", None),
                 ("CLAUDE_PLUGIN_ROOT", None),
-                ("CLAUDE_CONFIG_DIR", None),
                 ("HOME", Some("/home/testuser")),
             ],
             || {
@@ -171,24 +148,31 @@ mod tests {
 
     #[test]
     fn test_resolve_projects_dir_from_env() {
-        with_env_vars(&[("CTA_PROJECTS_DIR", Some("/custom/projects"))], || {
-            let path = resolve_projects_dir().unwrap();
-            assert_eq!(path, PathBuf::from("/custom/projects"));
-        });
+        with_env_vars(
+            &[
+                ("CTA_PROJECTS_DIR", Some("/custom/projects")),
+                ("CLAUDE_CONFIG_DIR", Some("/home/testuser/.config/claude")),
+            ],
+            || {
+                let path = resolve_projects_dir().unwrap();
+                assert_eq!(path, PathBuf::from("/custom/projects"));
+            },
+        );
     }
 
     #[test]
-    fn test_resolve_projects_dir_config_dir() {
+    fn test_resolve_projects_dir_from_config_dir() {
         with_env_vars(
             &[
                 ("CTA_PROJECTS_DIR", None),
-                ("CLAUDE_CONFIG_DIR", Some("/custom/claude-config")),
+                ("CLAUDE_CONFIG_DIR", Some("/home/testuser/.config/claude")),
+                ("HOME", Some("/home/testuser")),
             ],
             || {
                 let path = resolve_projects_dir().unwrap();
                 assert_eq!(
                     path,
-                    PathBuf::from("/custom/claude-config/projects")
+                    PathBuf::from("/home/testuser/.config/claude/projects")
                 );
             },
         );
@@ -210,64 +194,11 @@ mod tests {
     }
 
     #[test]
-    fn test_resolve_archive_dir_config_dir() {
-        with_env_vars(
-            &[
-                ("CTA_ARCHIVE_DIR", None),
-                ("CLAUDE_PLUGIN_ROOT", None),
-                ("CLAUDE_CONFIG_DIR", Some("/custom/claude-config")),
-            ],
-            || {
-                let path = resolve_archive_dir().unwrap();
-                assert_eq!(
-                    path,
-                    PathBuf::from("/custom/claude-config/token-analyzer-archive")
-                );
-            },
-        );
-    }
-
-    #[test]
-    fn test_plugin_root_takes_priority_over_config_dir() {
-        with_env_vars(
-            &[
-                ("CTA_DB_PATH", None),
-                ("CLAUDE_PLUGIN_ROOT", Some("/plugins/cta")),
-                ("CLAUDE_CONFIG_DIR", Some("/custom/claude-config")),
-            ],
-            || {
-                let path = resolve_db_path().unwrap();
-                assert_eq!(path, PathBuf::from("/plugins/cta/data/token-analyzer.db"));
-            },
-        );
-    }
-
-    #[test]
-    fn test_config_dir_fallback_without_home() {
+    fn test_resolve_fails_without_home() {
         with_env_vars(
             &[
                 ("CTA_DB_PATH", None),
                 ("CLAUDE_PLUGIN_ROOT", None),
-                ("CLAUDE_CONFIG_DIR", Some("/custom/claude-config")),
-                ("HOME", None),
-            ],
-            || {
-                let path = resolve_db_path().unwrap();
-                assert_eq!(
-                    path,
-                    PathBuf::from("/custom/claude-config/token-analyzer.db")
-                );
-            },
-        );
-    }
-
-    #[test]
-    fn test_resolve_fails_without_home_or_config_dir() {
-        with_env_vars(
-            &[
-                ("CTA_DB_PATH", None),
-                ("CLAUDE_PLUGIN_ROOT", None),
-                ("CLAUDE_CONFIG_DIR", None),
                 ("HOME", None),
             ],
             || {
@@ -278,6 +209,139 @@ mod tests {
                     err_msg.contains("HOME"),
                     "Error should mention HOME: {}",
                     err_msg
+                );
+            },
+        );
+    }
+
+    // ============================================================
+    // Path-resolution coverage for CLAUDE_CONFIG_DIR coexistence and precedence
+    // ============================================================
+
+    #[test]
+    fn test_resolve_archive_dir_from_env() {
+        with_env_vars(
+            &[
+                ("CTA_ARCHIVE_DIR", Some("/custom/archive")),
+                ("CLAUDE_PLUGIN_ROOT", None),
+                ("CLAUDE_CONFIG_DIR", None),
+            ],
+            || {
+                let path = resolve_archive_dir().unwrap();
+                assert_eq!(path, PathBuf::from("/custom/archive"));
+            },
+        );
+    }
+
+    #[test]
+    fn test_resolve_archive_dir_plugin_mode() {
+        with_env_vars(
+            &[
+                ("CTA_ARCHIVE_DIR", None),
+                ("CLAUDE_PLUGIN_ROOT", Some("/plugins/cta")),
+                ("CLAUDE_CONFIG_DIR", None),
+            ],
+            || {
+                let path = resolve_archive_dir().unwrap();
+                assert_eq!(
+                    path,
+                    PathBuf::from("/plugins/cta/data/token-analyzer-archive")
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn test_resolve_archive_dir_standalone() {
+        with_env_vars(
+            &[
+                ("CTA_ARCHIVE_DIR", None),
+                ("CLAUDE_PLUGIN_ROOT", None),
+                ("CLAUDE_CONFIG_DIR", None),
+                ("HOME", Some("/home/testuser")),
+            ],
+            || {
+                let path = resolve_archive_dir().unwrap();
+                assert_eq!(
+                    path,
+                    PathBuf::from("/home/testuser/.claude/token-analyzer-archive")
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn test_plugin_root_takes_priority_over_config_dir_for_archive() {
+        // When BOTH CLAUDE_PLUGIN_ROOT and CLAUDE_CONFIG_DIR are set,
+        // archive dir should use PLUGIN_ROOT (plugin mode takes highest priority).
+        with_env_vars(
+            &[
+                ("CTA_ARCHIVE_DIR", None),
+                ("CLAUDE_PLUGIN_ROOT", Some("/plugins/cta")),
+                ("CLAUDE_CONFIG_DIR", Some("/home/user/.config/claude")),
+                ("HOME", Some("/home/user")),
+            ],
+            || {
+                let path = resolve_archive_dir().unwrap();
+                assert_eq!(
+                    path,
+                    PathBuf::from("/plugins/cta/data/token-analyzer-archive"),
+                    "CLAUDE_PLUGIN_ROOT should take priority over CLAUDE_CONFIG_DIR for archive dir"
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn test_projects_ignore_plugin_root_without_config_dir() {
+        with_env_vars(
+            &[
+                ("CTA_PROJECTS_DIR", None),
+                ("CLAUDE_PLUGIN_ROOT", Some("/plugins/cta")),
+                ("CLAUDE_CONFIG_DIR", None),
+                ("HOME", Some("/home/user")),
+            ],
+            || {
+                let path = resolve_projects_dir().unwrap();
+                assert_eq!(path, PathBuf::from("/home/user/.claude/projects"));
+            },
+        );
+    }
+
+    #[test]
+    fn test_coexistence_plugin_root_and_config_dir_split_behavior() {
+        // When BOTH CLAUDE_PLUGIN_ROOT and CLAUDE_CONFIG_DIR are set:
+        //   db      → PLUGIN_ROOT/data/token-analyzer.db
+        //   archive → PLUGIN_ROOT/data/token-analyzer-archive
+        //   projects → CONFIG_DIR/projects  (NOT PLUGIN_ROOT/projects — Claude Code always writes here)
+        with_env_vars(
+            &[
+                ("CTA_DB_PATH", None),
+                ("CTA_ARCHIVE_DIR", None),
+                ("CTA_PROJECTS_DIR", None),
+                ("CLAUDE_PLUGIN_ROOT", Some("/plugins/cta")),
+                ("CLAUDE_CONFIG_DIR", Some("/home/user/.config/claude")),
+                ("HOME", Some("/home/user")),
+            ],
+            || {
+                let db_path = resolve_db_path().unwrap();
+                let archive_path = resolve_archive_dir().unwrap();
+                let projects_path = resolve_projects_dir().unwrap();
+
+                assert_eq!(
+                    db_path,
+                    PathBuf::from("/plugins/cta/data/token-analyzer.db"),
+                    "db should use PLUGIN_ROOT"
+                );
+                assert_eq!(
+                    archive_path,
+                    PathBuf::from("/plugins/cta/data/token-analyzer-archive"),
+                    "archive should use PLUGIN_ROOT"
+                );
+                assert_eq!(
+                    projects_path,
+                    PathBuf::from("/home/user/.config/claude/projects"),
+                    "projects should use CLAUDE_CONFIG_DIR (PR #7 feature)"
                 );
             },
         );

--- a/mcp-server/src/lib.rs
+++ b/mcp-server/src/lib.rs
@@ -9,4 +9,6 @@ pub mod parser;
 pub mod pricing;
 pub mod session_finder;
 pub mod storage;
+#[cfg(test)]
+pub mod test_utils;
 pub mod types;

--- a/mcp-server/src/pricing.rs
+++ b/mcp-server/src/pricing.rs
@@ -120,10 +120,7 @@ impl PricingTable {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Mutex;
-
-    /// Serialize env-var tests to avoid races
-    static PRICING_ENV_LOCK: Mutex<()> = Mutex::new(());
+    use crate::test_utils::with_env_vars;
 
     #[test]
     fn test_embedded_pricing() {
@@ -195,7 +192,6 @@ mod tests {
     #[test]
     fn test_from_env_or_embedded_uses_env() {
         use std::io::Write;
-        let _guard = PRICING_ENV_LOCK.lock().unwrap();
 
         let mut tmp = tempfile::NamedTempFile::new().unwrap();
         writeln!(
@@ -219,10 +215,9 @@ cache_read_per_mtok = 1.0
         .unwrap();
 
         let path = tmp.path().to_str().unwrap().to_string();
-        // SAFETY: serialized via PRICING_ENV_LOCK
-        unsafe { std::env::set_var("CTA_PRICING_PATH", &path) };
-        let table = PricingTable::from_env_or_embedded().unwrap();
-        unsafe { std::env::remove_var("CTA_PRICING_PATH") };
+        let table = with_env_vars(&[("CTA_PRICING_PATH", Some(path.as_str()))], || {
+            PricingTable::from_env_or_embedded().unwrap()
+        });
 
         let usage = TokenUsage {
             input_tokens: 1_000_000,
@@ -240,9 +235,9 @@ cache_read_per_mtok = 1.0
 
     #[test]
     fn test_from_env_or_embedded_fallback() {
-        let _guard = PRICING_ENV_LOCK.lock().unwrap();
-        unsafe { std::env::remove_var("CTA_PRICING_PATH") };
-        let table = PricingTable::from_env_or_embedded().unwrap();
+        let table = with_env_vars(&[("CTA_PRICING_PATH", None)], || {
+            PricingTable::from_env_or_embedded().unwrap()
+        });
         assert!(
             !table.config.models.is_empty(),
             "Fallback to embedded should have models"
@@ -251,10 +246,10 @@ cache_read_per_mtok = 1.0
 
     #[test]
     fn test_from_env_invalid_path_errors() {
-        let _guard = PRICING_ENV_LOCK.lock().unwrap();
-        unsafe { std::env::set_var("CTA_PRICING_PATH", "/nonexistent/pricing.toml") };
-        let result = PricingTable::from_env_or_embedded();
-        unsafe { std::env::remove_var("CTA_PRICING_PATH") };
+        let result = with_env_vars(
+            &[("CTA_PRICING_PATH", Some("/nonexistent/pricing.toml"))],
+            || PricingTable::from_env_or_embedded(),
+        );
 
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();

--- a/mcp-server/src/test_utils.rs
+++ b/mcp-server/src/test_utils.rs
@@ -1,0 +1,84 @@
+#[cfg(test)]
+use std::env;
+#[cfg(test)]
+use std::sync::{Mutex, MutexGuard};
+
+#[cfg(test)]
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+#[cfg(test)]
+struct EnvVarGuard {
+    originals: Vec<(String, Option<String>)>,
+    _guard: MutexGuard<'static, ()>,
+}
+
+#[cfg(test)]
+impl EnvVarGuard {
+    fn new(vars: &[(&str, Option<&str>)]) -> Self {
+        let guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let originals = vars
+            .iter()
+            .map(|(key, _)| ((*key).to_string(), env::var(key).ok()))
+            .collect();
+
+        for (key, value) in vars {
+            // SAFETY: all env-mutating tests share a single process-wide lock.
+            unsafe {
+                match value {
+                    Some(val) => env::set_var(key, val),
+                    None => env::remove_var(key),
+                }
+            }
+        }
+
+        Self {
+            originals,
+            _guard: guard,
+        }
+    }
+}
+
+#[cfg(test)]
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        for (key, original) in &self.originals {
+            // SAFETY: all env-mutating tests share a single process-wide lock.
+            unsafe {
+                match original {
+                    Some(value) => env::set_var(key, value),
+                    None => env::remove_var(key),
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+pub fn with_env_vars<F: FnOnce() -> R, R>(vars: &[(&str, Option<&str>)], f: F) -> R {
+    let _guard = EnvVarGuard::new(vars);
+    f()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::with_env_vars;
+    use std::env;
+
+    #[test]
+    fn test_with_env_vars_restores_after_panic() {
+        let result = std::panic::catch_unwind(|| {
+            with_env_vars(
+                &[("CTA_TEST_ENV_GUARD_RESTORE_AFTER_PANIC", Some("temp-value"))],
+                || {
+                    panic!("intentional panic to test env restoration");
+                },
+            );
+        });
+
+        assert!(result.is_err());
+        assert_eq!(
+            env::var("CTA_TEST_ENV_GUARD_RESTORE_AFTER_PANIC").ok(),
+            None
+        );
+    }
+}

--- a/worklog/session-c3362888-review-2026-04-14.md
+++ b/worklog/session-c3362888-review-2026-04-14.md
@@ -1,0 +1,73 @@
+# Session Review: c3362888-2dd3-4eb7-b374-ef21f6edc63b
+
+**Date:** 2026-04-14
+**Reviewed by:** Codex
+**Source artifacts:**
+- `/Users/liyuefong/.claude/projects/-Users-liyuefong-Desktop-claude-token-analyzer/c3362888-2dd3-4eb7-b374-ef21f6edc63b.jsonl`
+- `/Users/liyuefong/.claude/projects/-Users-liyuefong-Desktop-claude-token-analyzer/c3362888-2dd3-4eb7-b374-ef21f6edc63b/subagents/agent-af8860019ffa54569.jsonl`
+
+## What Happened
+
+- The prior Claude session switched to branch `fix/claude-config-dir-split-behavior`.
+- It reviewed four Copilot PR comments and explicitly said it would fix items 1-3 and defer item 4 as follow-up.
+- The session was interrupted by a rate-limit error before any verified completion message.
+- The only subagent (`agent-af8860019ffa54569`) was an Explore agent for digesting a separate Codex rollout log; it was interrupted by the user after oversized reads and produced no persisted handover file.
+
+## Verified Findings
+
+### Unfinished documentation fixes
+
+1. `README.md` still says the SQLite DB "lives in the plugin directory" even though standalone mode falls back to `~/.claude/token-analyzer.db`.
+   - Evidence: `README.md:50`
+2. `CLAUDE.md` still says `103 tests`, but current suite is 105 tests.
+   - Evidence: `CLAUDE.md:11`
+   - Verification: `cargo test --all-targets --manifest-path mcp-server/Cargo.toml -- --list` showed `90` unit tests and `15` integration tests.
+3. `mcp-server/src/config.rs` module header still implies `$CLAUDE_CONFIG_DIR` is a global fallback stage, instead of projects-only behavior.
+   - Evidence: `mcp-server/src/config.rs:3-7`
+
+### Real test-isolation bug remains
+
+4. `config.rs` test helper restores env vars only on the happy path.
+   - Evidence: `mcp-server/src/config.rs:76-106`
+   - If `f()` panics, the restore loop is skipped and process env can leak into later tests.
+5. `pricing.rs` has a separate local env mutex and manual `set_var/remove_var` pairs.
+   - Evidence: `mcp-server/src/pricing.rs:126-157`, `mcp-server/src/pricing.rs:196-256`
+   - This means env-mutating tests are not globally serialized across modules, so Copilot's deeper concern is valid.
+
+## Verification Snapshot
+
+- Current branch: `fix/claude-config-dir-split-behavior`
+- `cargo test --all-targets --manifest-path mcp-server/Cargo.toml` currently passes (`105` tests total), so the bug is latent test infrastructure debt rather than a red build.
+- Working tree before my fixes had only untracked local artifacts:
+  - `.codex-test/`
+  - `worklog/`
+
+## Next Step
+
+1. Introduce one shared, panic-safe test env guard utility.
+2. Migrate both `config.rs` and `pricing.rs` tests to use it.
+3. Fix the three stale documentation strings.
+4. Re-run full `cargo test --all-targets` and use that output as the final evidence.
+
+## Resolution Applied
+
+- Added shared test helper `mcp-server/src/test_utils.rs` with a single process-wide env mutex and `Drop`-based restoration.
+- Migrated `config.rs` tests and `pricing.rs` env-path tests to use the shared helper instead of per-module env locking.
+- Added a regression test proving env vars are restored even when the wrapped closure panics.
+- Corrected stale split-behavior docs in:
+  - `README.md`
+  - `CLAUDE.md`
+  - `mcp-server/src/config.rs`
+
+## Final Verification
+
+Command run:
+
+```bash
+cargo test --all-targets --manifest-path mcp-server/Cargo.toml
+```
+
+Observed result:
+- `91` unit tests passed
+- `15` integration tests passed
+- Total: `106` tests passed, `0` failed


### PR DESCRIPTION
## Summary

Supersedes #7 with a split-behavior adjustment for #6.

Builds on @halindrome's PR #7 (cherry-picked as first 5 commits with authorship preserved), then narrows the scope so only `resolve_projects_dir()` gains a `CLAUDE_CONFIG_DIR` fallback. `resolve_db_path()` and `resolve_archive_dir()` stay three-mode (`CTA_* env > CLAUDE_PLUGIN_ROOT > $HOME/.claude`).

## Why split behavior

- **Session JSONL** are written by Claude Code into its config dir, so CTA must follow `$CLAUDE_CONFIG_DIR/projects` when set. `resolve_projects_dir()` gets the fallback.
- **CTA's own DB + archive** are our persistence. If we tie them to `$CLAUDE_CONFIG_DIR`, a user retargeting that variable would silently lose access to their historical data. Instead they stay anchored to plugin install location (or `$HOME/.claude` in standalone mode).

## Changes vs PR #7

| Area | PR #7 | This PR |
|---|---|---|
| `resolve_projects_dir` CLAUDE_CONFIG_DIR | ✅ | ✅ (kept) |
| `resolve_db_path` CLAUDE_CONFIG_DIR | ✅ | ❌ (reverted) |
| `resolve_archive_dir` CLAUDE_CONFIG_DIR | ✅ | ❌ (reverted) |
| `claude_config_dir_or_home()` helper | added | removed (inlined for clarity) |
| Split-behavior tests | — | added 3 new tests |
| Copilot follow-up on env test isolation | — | ✅ shared panic-safe env guard |
| Total tests | 103 | 106 |

## Commits

- `dd9cc8c..550bf22` — cherry-picked from PR #7 (authored by @halindrome)
- `417d352` — split-behavior refactor
- `88d5985` — harden env-var test isolation and align split-behavior docs

## Test plan

- [x] `cargo test --all-targets --manifest-path mcp-server/Cargo.toml` → 106 passed (91 unit + 15 integration)
- [x] Split-behavior tests cover:
  - `test_plugin_root_takes_priority_over_config_dir_for_archive`
  - `test_projects_ignore_plugin_root_without_config_dir`
  - `test_coexistence_plugin_root_and_config_dir_split_behavior`
- [x] Panic-safe env restoration is covered by:
  - `test_with_env_vars_restores_after_panic`

## Closes

Closes #6  
Supersedes #7

Thanks to @halindrome for surfacing the issue and the initial implementation.
