### PR TITLE
[fix] Correct model pricing and add the Claude 5 family

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@ filled only when the corresponding tag is published.
 - Installer downloads are time-bounded with bounded retries, stale installer
   temp files are swept, and the tag-time release gate now runs the plugin
   validate and marketplace install contracts.
+- The pricing table covers the Claude 5 family and all current 4.x models;
+  stale Opus 4.6 and Haiku 4.5 rates are corrected to current list prices, and
+  dated legacy model IDs resolve via aliases instead of silently falling back
+  to Sonnet-equivalent defaults.
 
 ### Integrity boundary
 

--- a/mcp-server/config/pricing.toml
+++ b/mcp-server/config/pricing.toml
@@ -2,16 +2,87 @@
 # Field mapping to JSONL usage fields:
 #   input_per_mtok          → input_tokens
 #   output_per_mtok         → output_tokens
-#   cache_creation_per_mtok → cache_creation_input_tokens
-#   cache_read_per_mtok     → cache_read_input_tokens
+#   cache_creation_per_mtok → cache_creation_input_tokens (5-minute TTL write = 1.25x input)
+#   cache_read_per_mtok     → cache_read_input_tokens (= 0.1x input)
+#
+# Prices are Anthropic first-party API sticker rates. Time-limited introductory
+# discounts (e.g. Sonnet 5 launch pricing) are not modeled.
+
+# ── Claude 5 family ──────────────────────────────────────────────
+
+[[models]]
+id = "claude-fable-5"
+aliases = []
+input_per_mtok = 10.0
+output_per_mtok = 50.0
+cache_creation_per_mtok = 12.5
+cache_read_per_mtok = 1.0
+
+[[models]]
+id = "claude-mythos-5"
+aliases = ["claude-mythos-preview"]
+input_per_mtok = 10.0
+output_per_mtok = 50.0
+cache_creation_per_mtok = 12.5
+cache_read_per_mtok = 1.0
+
+[[models]]
+id = "claude-opus-5"
+aliases = []
+input_per_mtok = 5.0
+output_per_mtok = 25.0
+cache_creation_per_mtok = 6.25
+cache_read_per_mtok = 0.50
+
+[[models]]
+id = "claude-sonnet-5"
+aliases = []
+input_per_mtok = 3.0
+output_per_mtok = 15.0
+cache_creation_per_mtok = 3.75
+cache_read_per_mtok = 0.30
+
+# ── Claude 4.x family ────────────────────────────────────────────
+
+[[models]]
+id = "claude-opus-4-8"
+aliases = []
+input_per_mtok = 5.0
+output_per_mtok = 25.0
+cache_creation_per_mtok = 6.25
+cache_read_per_mtok = 0.50
+
+[[models]]
+id = "claude-opus-4-7"
+aliases = []
+input_per_mtok = 5.0
+output_per_mtok = 25.0
+cache_creation_per_mtok = 6.25
+cache_read_per_mtok = 0.50
 
 [[models]]
 id = "claude-opus-4-6"
 aliases = ["claude-opus-4-6-20250610"]
+input_per_mtok = 5.0
+output_per_mtok = 25.0
+cache_creation_per_mtok = 6.25
+cache_read_per_mtok = 0.50
+
+[[models]]
+id = "claude-opus-4-5"
+aliases = ["claude-opus-4-5-20251101"]
+input_per_mtok = 5.0
+output_per_mtok = 25.0
+cache_creation_per_mtok = 6.25
+cache_read_per_mtok = 0.50
+
+[[models]]
+id = "claude-opus-4-1"
+aliases = ["claude-opus-4-1-20250805"]
 input_per_mtok = 15.0
 output_per_mtok = 75.0
-cache_creation_per_mtok = 3.75
-cache_read_per_mtok = 0.75
+cache_creation_per_mtok = 18.75
+cache_read_per_mtok = 1.50
 
 [[models]]
 id = "claude-sonnet-4-6"
@@ -22,13 +93,30 @@ cache_creation_per_mtok = 3.75
 cache_read_per_mtok = 0.30
 
 [[models]]
+id = "claude-sonnet-4-5"
+aliases = ["claude-sonnet-4-5-20250929"]
+input_per_mtok = 3.0
+output_per_mtok = 15.0
+cache_creation_per_mtok = 3.75
+cache_read_per_mtok = 0.30
+
+[[models]]
+id = "claude-sonnet-4-0"
+aliases = ["claude-sonnet-4-20250514"]
+input_per_mtok = 3.0
+output_per_mtok = 15.0
+cache_creation_per_mtok = 3.75
+cache_read_per_mtok = 0.30
+
+[[models]]
 id = "claude-haiku-4-5"
 aliases = ["claude-haiku-4-5-20251001"]
-input_per_mtok = 0.80
-output_per_mtok = 4.0
-cache_creation_per_mtok = 1.0
-cache_read_per_mtok = 0.08
+input_per_mtok = 1.0
+output_per_mtok = 5.0
+cache_creation_per_mtok = 1.25
+cache_read_per_mtok = 0.10
 
+# Unknown models fall back to Sonnet-equivalent pricing.
 [defaults]
 input_per_mtok = 3.0
 output_per_mtok = 15.0

--- a/mcp-server/src/pricing.rs
+++ b/mcp-server/src/pricing.rs
@@ -142,13 +142,67 @@ mod tests {
         };
         let cost = table.calculate_cost("claude-opus-4-6", &usage);
 
-        // opus pricing: input=15, output=75, cache_creation=3.75, cache_read=0.75
+        // opus pricing: input=5, output=25, cache_creation=6.25, cache_read=0.50
         let epsilon = 0.001;
+        assert!((cost.input_cost - 5.0).abs() < epsilon);
+        assert!((cost.output_cost - 25.0).abs() < epsilon);
+        assert!((cost.cache_creation_cost - 6.25).abs() < epsilon);
+        assert!((cost.cache_read_cost - 0.50).abs() < epsilon);
+        assert!((cost.total_cost - 36.75).abs() < epsilon);
+    }
+
+    #[test]
+    fn test_claude_5_family_pricing() {
+        let table = PricingTable::embedded();
+        let usage = TokenUsage {
+            input_tokens: 1_000_000,
+            output_tokens: 1_000_000,
+            cache_creation_input_tokens: 1_000_000,
+            cache_read_input_tokens: 1_000_000,
+        };
+        let epsilon = 0.001;
+
+        // (model, input, output, cache_creation, cache_read) per MTok
+        let expected = [
+            ("claude-fable-5", 10.0, 50.0, 12.5, 1.0),
+            ("claude-mythos-5", 10.0, 50.0, 12.5, 1.0),
+            ("claude-opus-5", 5.0, 25.0, 6.25, 0.50),
+            ("claude-sonnet-5", 3.0, 15.0, 3.75, 0.30),
+            ("claude-opus-4-8", 5.0, 25.0, 6.25, 0.50),
+            ("claude-opus-4-7", 5.0, 25.0, 6.25, 0.50),
+            ("claude-opus-4-1", 15.0, 75.0, 18.75, 1.50),
+            ("claude-haiku-4-5", 1.0, 5.0, 1.25, 0.10),
+        ];
+        for (model, inp, out, cc, cr) in expected {
+            let cost = table.calculate_cost(model, &usage);
+            assert!((cost.input_cost - inp).abs() < epsilon, "{model} input");
+            assert!((cost.output_cost - out).abs() < epsilon, "{model} output");
+            assert!(
+                (cost.cache_creation_cost - cc).abs() < epsilon,
+                "{model} cache_creation"
+            );
+            assert!((cost.cache_read_cost - cr).abs() < epsilon, "{model} cache_read");
+        }
+    }
+
+    #[test]
+    fn test_legacy_dated_ids_resolve_via_aliases() {
+        let table = PricingTable::embedded();
+        let usage = TokenUsage {
+            input_tokens: 1_000_000,
+            output_tokens: 0,
+            cache_creation_input_tokens: 0,
+            cache_read_input_tokens: 0,
+        };
+        let epsilon = 0.001;
+
+        // Dated IDs seen in real session logs must not fall back to defaults.
+        let cost = table.calculate_cost("claude-sonnet-4-20250514", &usage);
+        assert!((cost.input_cost - 3.0).abs() < epsilon);
+        let cost = table.calculate_cost("claude-opus-4-5-20251101", &usage);
+        assert!((cost.input_cost - 5.0).abs() < epsilon);
+        let cost = table.calculate_cost("claude-opus-4-1-20250805", &usage);
         assert!((cost.input_cost - 15.0).abs() < epsilon);
-        assert!((cost.output_cost - 75.0).abs() < epsilon);
-        assert!((cost.cache_creation_cost - 3.75).abs() < epsilon);
-        assert!((cost.cache_read_cost - 0.75).abs() < epsilon);
-        assert!((cost.total_cost - 94.5).abs() < epsilon);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

The pricing table was silently mispricing today's sessions — an existential correctness issue for a cost-diagnosis tool:

- **Opus 4.6 was listed at Opus 4.1-era rates** ($15/$75 per MTok) — a 3x overstatement of the current $5/$25 list price
- **Haiku 4.5 carried Haiku 3.5 rates** ($0.80/$4 instead of $1/$5)
- **Every Claude 5 session fell back to Sonnet-equivalent defaults** — Fable/Mythos costs underestimated ~3x, with no signal that the number was a guess
- Dated legacy IDs seen in real session logs (`claude-sonnet-4-20250514`, `claude-opus-4-5-20251101`, …) silently hit the default fallback

## Changes

- All current first-party models now have entries: Fable 5, Mythos 5, Opus 5, Sonnet 5, Opus 4.5–4.8, Opus 4.1, Sonnet 4.0/4.5/4.6, Haiku 4.5
- Cache-write priced at 1.25x input (5-minute TTL), cache-read at 0.1x input, consistently across all entries
- Dated legacy IDs resolve via aliases instead of the silent default fallback
- Sticker prices only; time-limited introductory discounts (Sonnet 5 launch pricing) are documented as not modeled
- New tests pin every family entry and the legacy alias resolution (`test_claude_5_family_pricing`, `test_legacy_dated_ids_resolve_via_aliases`); the existing Opus 4.6 expectation is corrected

## Verification

- `cargo test --all-targets --locked`: 183 passed, 0 failed
- `cargo clippy --all-targets --locked -- -D warnings`: passed

## Sequencing

Stacked on `feat/community-feedback` (#14) so CI runs against the clippy-clean, locked baseline; contains exactly one commit of its own. Merge **after #14 and before tagging `v0.3.0`** so the release ships with trustworthy numbers. Users can still override at runtime via `CTA_PRICING_PATH`.

https://claude.ai/code/session_015tRUVv9GW8DozaK3QxnyzM
